### PR TITLE
Adds externally managed sprout-terminal cookbook

### DIFF
--- a/Cheffile
+++ b/Cheffile
@@ -24,6 +24,10 @@ cookbook 'sprout-pivotal',
   :git => 'git://github.com/pivotal-sprout/sprout.git',
   :path => 'sprout-pivotal'
 
+cookbook 'sprout-terminal', '>=0.2.0',
+  :git => 'git://github.com/codeword/sprout-terminal.git',
+  :path => '.'
+
 cookbook 'osx',
   :git => 'git://github.com/pivotal-sprout/sprout.git',
   :path => 'osx'

--- a/Cheffile.lock
+++ b/Cheffile.lock
@@ -4,6 +4,15 @@ SITE
     dmg (2.0.4)
 
 GIT
+  remote: git://github.com/codeword/sprout-terminal.git
+  path: .
+  ref: master
+  sha: 2767f86028376cc4cadd93b56bdc25b2c37fba8b
+  specs:
+    sprout-terminal (0.2.0)
+      osx (>= 0.0.0)
+
+GIT
   remote: git://github.com/pivotal-sprout/sprout.git
   path: osx
   ref: master
@@ -81,4 +90,5 @@ DEPENDENCIES
   sprout-osx-base (>= 0)
   sprout-osx-settings (>= 0)
   sprout-pivotal (>= 0)
+  sprout-terminal (>= 0.2.0)
 

--- a/soloistrc
+++ b/soloistrc
@@ -57,6 +57,9 @@ recipes:
 - pivotal_workstation::rubymine
 - pivotal_workstation::rubymine_preferences_pivotal
 
+# custom
+- sprout-terminal
+
 node_attributes:
   git_pairs_domain: pivotallabs.com
   git_pairs_authors:


### PR DESCRIPTION
This commit adds the sprout-terminal cookbook to sprout-wrap.  This cookbook is managed outside of the core sprout repository and can be used as an example for how to define custom cookbooks to be included in sprout-wrap.  

Without changing any configuration the sprout-terminal cookbook will simply set the startup and default profiles to 'Basic' (which is the mac osx default) and will set the 'close window' setting to 'when terminal exits cleanly'.
