### PR TITLE
Replaces some app install recipes with sprout-homebrew

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 tmp/
 cookbooks/
+.bundle/

--- a/Cheffile
+++ b/Cheffile
@@ -1,5 +1,3 @@
-site 'http://community.opscode.com/api/v1'
-
 cookbook 'meta',
   :path => 'site-cookbooks/meta'
 
@@ -38,3 +36,8 @@ cookbook 'osx',
 cookbook 'sprout-osx-rubymine',
   :git => 'git://github.com/pivotal-sprout/sprout.git',
   :path => 'sprout-osx-rubymine'
+
+cookbook 'sprout-homebrew',
+  :git => 'git://github.com/pivotal-sprout/sprout-homebrew.git'
+
+site 'http://community.opscode.com/api/v1'

--- a/Cheffile.lock
+++ b/Cheffile.lock
@@ -1,14 +1,22 @@
 SITE
   remote: http://community.opscode.com/api/v1
   specs:
-    dmg (2.0.8)
-    homebrew (1.5.2)
+    dmg (2.1.2)
+    homebrew (1.5.4)
+
+GIT
+  remote: git://github.com/pivotal-sprout/sprout-homebrew.git
+  ref: master
+  sha: dde985746fa3e552ea4d4ffb7ffea8568100845c
+  specs:
+    sprout-homebrew (0.1.0)
+      homebrew (>= 0.0.0)
 
 GIT
   remote: git://github.com/pivotal-sprout/sprout.git
   path: osx
   ref: master
-  sha: 1c86456712112273d8737a1744859eb3adb6ca86
+  sha: 2baedb853f3516156365f73438c27a1f4c6d7059
   specs:
     osx (0.1.0)
 
@@ -16,7 +24,7 @@ GIT
   remote: git://github.com/pivotal-sprout/sprout.git
   path: pivotal_workstation
   ref: master
-  sha: 1c86456712112273d8737a1744859eb3adb6ca86
+  sha: 2baedb853f3516156365f73438c27a1f4c6d7059
   specs:
     pivotal_workstation (1.0.0)
       dmg (>= 0.0.0)
@@ -31,7 +39,7 @@ GIT
   remote: git://github.com/pivotal-sprout/sprout.git
   path: sprout-osx-apps
   ref: master
-  sha: 1c86456712112273d8737a1744859eb3adb6ca86
+  sha: 2baedb853f3516156365f73438c27a1f4c6d7059
   specs:
     sprout-osx-apps (0.1.0)
       dmg (>= 0.0.0)
@@ -43,7 +51,7 @@ GIT
   remote: git://github.com/pivotal-sprout/sprout.git
   path: sprout-osx-base
   ref: master
-  sha: 1c86456712112273d8737a1744859eb3adb6ca86
+  sha: 2baedb853f3516156365f73438c27a1f4c6d7059
   specs:
     sprout-osx-base (0.1.0)
 
@@ -51,7 +59,7 @@ GIT
   remote: git://github.com/pivotal-sprout/sprout.git
   path: sprout-osx-git
   ref: master
-  sha: 1c86456712112273d8737a1744859eb3adb6ca86
+  sha: 2baedb853f3516156365f73438c27a1f4c6d7059
   specs:
     sprout-osx-git (0.1.0)
       homebrew (>= 0.0.0)
@@ -61,7 +69,7 @@ GIT
   remote: git://github.com/pivotal-sprout/sprout.git
   path: sprout-osx-rbenv
   ref: master
-  sha: 1c86456712112273d8737a1744859eb3adb6ca86
+  sha: 2baedb853f3516156365f73438c27a1f4c6d7059
   specs:
     sprout-osx-rbenv (0.1.0)
       homebrew (>= 0.0.0)
@@ -71,7 +79,7 @@ GIT
   remote: git://github.com/pivotal-sprout/sprout.git
   path: sprout-osx-rubymine
   ref: master
-  sha: 1c86456712112273d8737a1744859eb3adb6ca86
+  sha: 2baedb853f3516156365f73438c27a1f4c6d7059
   specs:
     sprout-osx-rubymine (0.1.0)
       homebrew (>= 0.0.0)
@@ -82,7 +90,7 @@ GIT
   remote: git://github.com/pivotal-sprout/sprout.git
   path: sprout-osx-settings
   ref: master
-  sha: 1c86456712112273d8737a1744859eb3adb6ca86
+  sha: 2baedb853f3516156365f73438c27a1f4c6d7059
   specs:
     sprout-osx-settings (0.1.0)
       homebrew (>= 0.0.0)
@@ -93,7 +101,7 @@ GIT
   remote: git://github.com/pivotal-sprout/sprout.git
   path: sprout-pivotal
   ref: master
-  sha: 1c86456712112273d8737a1744859eb3adb6ca86
+  sha: 2baedb853f3516156365f73438c27a1f4c6d7059
   specs:
     sprout-pivotal (0.1.0)
       dmg (>= 0.0.0)
@@ -112,6 +120,7 @@ DEPENDENCIES
   meta (>= 0)
   osx (>= 0)
   pivotal_workstation (>= 0)
+  sprout-homebrew (>= 0)
   sprout-osx-apps (>= 0)
   sprout-osx-base (>= 0)
   sprout-osx-git (>= 0)

--- a/soloistrc
+++ b/soloistrc
@@ -30,21 +30,12 @@ recipes:
 
 # apps
 - pivotal_workstation::screen_sharing_app
-- sprout-osx-apps::skype
 - sprout-osx-apps::shiftit
-- sprout-osx-apps::firefox
-- sprout-osx-apps::dropbox
-- sprout-osx-apps::chrome
 - pivotal_workstation::mouse_locator
 - sprout-osx-apps::menumeters
-- pivotal_workstation::bettertouchtool
 - sprout-osx-apps::ccmenu
 - pivotal_workstation::github_for_mac
-- sprout-osx-apps::gitx
-- sprout-osx-apps::iterm2
 - sprout-osx-apps::keycastr
-- sprout-osx-apps::virtualbox
-- sprout-osx-apps::vagrant
 
 # apps (editors)
 - sprout-osx-apps::textmate
@@ -55,6 +46,8 @@ recipes:
 - sprout-osx-apps::ctags_exuberant
 
 - sprout-osx-apps::rubymine
+
+- sprout-homebrew
 - sprout-osx-rubymine::preferences
 
 node_attributes:
@@ -75,3 +68,16 @@ node_attributes:
     -
       - sprout-wrap
       - https://github.com/pivotal-sprout/sprout-wrap.git
+  sprout:
+    homebrew:
+      casks:
+        - bettertouchtool
+        - dropbox
+        - firefox
+        - gitx
+        - google-chrome
+        - iterm2
+        - rubymine
+        - skype
+        - vagrant
+        - virtualbox


### PR DESCRIPTION
-We are now installing some of the applications via sprout-homebrew
  cask configurations.
-Also moves inclusion of opscode site cookbooks after all custom
cookbooks to make opscode the default but easily overridden when
necessary.
-Updates the Cheffile.lock

[#61595486]
