### PR TITLE
Replaces some app install recipes with sprout-homebrew

### DIFF
--- a/Cheffile
+++ b/Cheffile
@@ -38,3 +38,6 @@ cookbook 'osx',
 cookbook 'sprout-osx-rubymine',
   :git => 'git://github.com/pivotal-sprout/sprout.git',
   :path => 'sprout-osx-rubymine'
+
+cookbook 'sprout-homebrew',
+  :git => 'git://github.com/pivotal-sprout/sprout-homebrew.git'

--- a/Cheffile.lock
+++ b/Cheffile.lock
@@ -2,7 +2,15 @@ SITE
   remote: http://community.opscode.com/api/v1
   specs:
     dmg (2.0.8)
-    homebrew (1.5.2)
+    homebrew (1.5.4)
+
+GIT
+  remote: git://github.com/pivotal-sprout/sprout-homebrew.git
+  ref: master
+  sha: dde985746fa3e552ea4d4ffb7ffea8568100845c
+  specs:
+    sprout-homebrew (0.1.0)
+      homebrew (>= 0.0.0)
 
 GIT
   remote: git://github.com/pivotal-sprout/sprout.git
@@ -112,6 +120,7 @@ DEPENDENCIES
   meta (>= 0)
   osx (>= 0)
   pivotal_workstation (>= 0)
+  sprout-homebrew (>= 0)
   sprout-osx-apps (>= 0)
   sprout-osx-base (>= 0)
   sprout-osx-git (>= 0)

--- a/soloistrc
+++ b/soloistrc
@@ -30,21 +30,13 @@ recipes:
 
 # apps
 - pivotal_workstation::screen_sharing_app
-- sprout-osx-apps::skype
 - sprout-osx-apps::shiftit
-- sprout-osx-apps::firefox
-- sprout-osx-apps::dropbox
-- sprout-osx-apps::chrome
 - pivotal_workstation::mouse_locator
 - sprout-osx-apps::menumeters
-- pivotal_workstation::bettertouchtool
 - sprout-osx-apps::ccmenu
 - pivotal_workstation::github_for_mac
-- sprout-osx-apps::gitx
 - sprout-osx-apps::iterm2
 - sprout-osx-apps::keycastr
-- sprout-osx-apps::virtualbox
-- sprout-osx-apps::vagrant
 
 # apps (editors)
 - sprout-osx-apps::textmate
@@ -56,6 +48,8 @@ recipes:
 
 - sprout-osx-apps::rubymine
 - sprout-osx-rubymine::preferences
+
+- sprout-homebrew
 
 node_attributes:
   git_pairs_domain: pivotallabs.com
@@ -75,3 +69,14 @@ node_attributes:
     -
       - sprout-wrap
       - https://github.com/pivotal-sprout/sprout-wrap.git
+  sprout:
+    homebrew:
+      casks:
+        - bettertouchtool
+        - dropbox
+        - firefox
+        - gitx-rowanj
+        - google-chrome
+        - skype
+        - vagrant
+        - virtualbox


### PR DESCRIPTION
- All app install recipes that were basic package installs are replaced with
  sprout-homebrew and cask configurations.
- Updates homebrew version to latest(1.5.4) as 1.5.2 was broken

[completes #61595486]
