### PR TITLE
Update Cheffile.lock to point to most recent versions

### DIFF
--- a/Cheffile.lock
+++ b/Cheffile.lock
@@ -1,13 +1,13 @@
 SITE
   remote: http://community.opscode.com/api/v1
   specs:
-    dmg (2.0.8)
+    dmg (2.1.2)
     homebrew (1.5.4)
 
 GIT
   remote: git://github.com/pivotal-sprout/sprout-homebrew.git
   ref: master
-  sha: dde985746fa3e552ea4d4ffb7ffea8568100845c
+  sha: 25251cec3bc0325fcc2f3b6ebb5ce3d135414cca
   specs:
     sprout-homebrew (0.1.0)
       homebrew (>= 0.0.0)
@@ -16,7 +16,7 @@ GIT
   remote: git://github.com/pivotal-sprout/sprout.git
   path: osx
   ref: master
-  sha: 1c86456712112273d8737a1744859eb3adb6ca86
+  sha: 2baedb853f3516156365f73438c27a1f4c6d7059
   specs:
     osx (0.1.0)
 
@@ -24,7 +24,7 @@ GIT
   remote: git://github.com/pivotal-sprout/sprout.git
   path: pivotal_workstation
   ref: master
-  sha: 1c86456712112273d8737a1744859eb3adb6ca86
+  sha: 2baedb853f3516156365f73438c27a1f4c6d7059
   specs:
     pivotal_workstation (1.0.0)
       dmg (>= 0.0.0)
@@ -39,7 +39,7 @@ GIT
   remote: git://github.com/pivotal-sprout/sprout.git
   path: sprout-osx-apps
   ref: master
-  sha: 1c86456712112273d8737a1744859eb3adb6ca86
+  sha: 2baedb853f3516156365f73438c27a1f4c6d7059
   specs:
     sprout-osx-apps (0.1.0)
       dmg (>= 0.0.0)
@@ -51,7 +51,7 @@ GIT
   remote: git://github.com/pivotal-sprout/sprout.git
   path: sprout-osx-base
   ref: master
-  sha: 1c86456712112273d8737a1744859eb3adb6ca86
+  sha: 2baedb853f3516156365f73438c27a1f4c6d7059
   specs:
     sprout-osx-base (0.1.0)
 
@@ -59,7 +59,7 @@ GIT
   remote: git://github.com/pivotal-sprout/sprout.git
   path: sprout-osx-git
   ref: master
-  sha: 1c86456712112273d8737a1744859eb3adb6ca86
+  sha: 2baedb853f3516156365f73438c27a1f4c6d7059
   specs:
     sprout-osx-git (0.1.0)
       homebrew (>= 0.0.0)
@@ -69,7 +69,7 @@ GIT
   remote: git://github.com/pivotal-sprout/sprout.git
   path: sprout-osx-rbenv
   ref: master
-  sha: 1c86456712112273d8737a1744859eb3adb6ca86
+  sha: 2baedb853f3516156365f73438c27a1f4c6d7059
   specs:
     sprout-osx-rbenv (0.1.0)
       homebrew (>= 0.0.0)
@@ -79,7 +79,7 @@ GIT
   remote: git://github.com/pivotal-sprout/sprout.git
   path: sprout-osx-rubymine
   ref: master
-  sha: 1c86456712112273d8737a1744859eb3adb6ca86
+  sha: 2baedb853f3516156365f73438c27a1f4c6d7059
   specs:
     sprout-osx-rubymine (0.1.0)
       homebrew (>= 0.0.0)
@@ -90,7 +90,7 @@ GIT
   remote: git://github.com/pivotal-sprout/sprout.git
   path: sprout-osx-settings
   ref: master
-  sha: 1c86456712112273d8737a1744859eb3adb6ca86
+  sha: 2baedb853f3516156365f73438c27a1f4c6d7059
   specs:
     sprout-osx-settings (0.1.0)
       homebrew (>= 0.0.0)
@@ -101,7 +101,7 @@ GIT
   remote: git://github.com/pivotal-sprout/sprout.git
   path: sprout-pivotal
   ref: master
-  sha: 1c86456712112273d8737a1744859eb3adb6ca86
+  sha: 2baedb853f3516156365f73438c27a1f4c6d7059
   specs:
     sprout-pivotal (0.1.0)
       dmg (>= 0.0.0)
@@ -111,10 +111,11 @@ GIT
 PATH
   remote: site-cookbooks/meta
   specs:
-    meta (0.1.0)
+    meta (0.1.1)
       pivotal_workstation (>= 0.0.0)
       sprout-osx-apps (>= 0.0.0)
       sprout-osx-settings (>= 0.0.0)
+      sprout-pivotal (>= 0.0.0)
 
 DEPENDENCIES
   meta (>= 0)


### PR DESCRIPTION
Cheffile.lock now points to most recent shas, ensuring that sprout-wrap builds successfully on Mavericks.
