### PR TITLE
Removes bettertouchtool

### DIFF
--- a/soloistrc
+++ b/soloistrc
@@ -75,7 +75,6 @@ node_attributes:
       clock_format: EEE MMM d  h:mm:ss a
     homebrew:
       casks:
-        - bettertouchtool
         - dropbox
         - firefox
         - gitx-rowanj


### PR DESCRIPTION
- We don't think this is a heavily used utility
- it wasn't able to download which meant we couldn't build a developer image

==> Downloading http://www.boastr.de/BetterTouchTool.zip
curl: (7) Failed connect to www.boastr.de:80; Connection refused
