### PR TITLE
Better terminal

### DIFF
--- a/Cheffile
+++ b/Cheffile
@@ -43,3 +43,6 @@ cookbook 'sprout-osx-rubymine',
 
 cookbook 'sprout-homebrew',
   :github => 'pivotal-sprout/sprout-homebrew'
+
+cookbook 'sprout-terminal',
+  :github => 'pivotal-sprout/sprout-terminal'

--- a/Cheffile.lock
+++ b/Cheffile.lock
@@ -108,6 +108,14 @@ GIT
     sprout-homebrew (0.1.0)
       homebrew (>= 0.0.0)
 
+GIT
+  remote: https://github.com/pivotal-sprout/sprout-terminal
+  ref: master
+  sha: d238fd546063112c9536317f1912a649af6b16f1
+  specs:
+    sprout-terminal (0.2.0)
+      osx (>= 0.0.0)
+
 PATH
   remote: site-cookbooks/meta
   specs:
@@ -129,4 +137,5 @@ DEPENDENCIES
   sprout-osx-rubymine (>= 0)
   sprout-osx-settings (>= 0)
   sprout-pivotal (>= 0)
+  sprout-terminal (>= 0)
 

--- a/soloistrc
+++ b/soloistrc
@@ -12,6 +12,7 @@ recipes:
 - pivotal_workstation::locate_on
 - sprout-osx-settings::global_environment_variables
 - sprout-osx-settings::set_menubar_clock_format
+- sprout-terminal
 
 # development (general)
 - sprout-osx-base::workspace_directory
@@ -71,6 +72,9 @@ node_attributes:
       - sprout-wrap
       - https://github.com/pivotal-sprout/sprout-wrap.git
   sprout:
+    terminal:
+      default_profile: 'Pro'
+      update_font: true
     settings:
       clock_format: EEE MMM d  h:mm:ss a
     homebrew:


### PR DESCRIPTION
Adds sprout-terminal cookbook 

Runs the default recipe and sets terminal default profile to use "Pro" with Menlo 18pt font.
