### PR TITLE
Annotate some Mavericks specific changes to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ Don't forget to start up Xcode once it's installed so that you can agree to the 
 ### 2. Install Command Line Tools
   
     xcode-select --install
-  
+
+If you receive a message about the update server being unavailable and are on Mavericks, then you already have the command line tools.
+
 ### 3. Clone this project
 
     git clone https://github.com/pivotal-sprout/sprout-wrap.git
@@ -36,6 +38,14 @@ If you're running under rvm or rbenv, you shouldn't preface the following comman
 
     sudo gem install bundler
     sudo bundle
+
+If you receive errors like this:
+
+    clang: error: unknown argument: '-multiply_definedsuppress'
+
+then try downgrading those errors like this:
+
+    sudo ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future bundle
 
 ### 5. Run soloist
 


### PR DESCRIPTION
Had some trouble with SproutWrap, OSX 10.9.2, and Xcode Version 5.1 (5B130a).

Annotated the fixes I used in the README. Hope this helps.
