### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you receive a message about the update server being unavailable and are on Ma
 If you're running under rvm or rbenv, you shouldn't preface the following commands with `sudo`.
 
     sudo gem install bundler
-    sudo bundle
+    bundle
 
 If you receive errors like this:
 


### PR DESCRIPTION
Bundle raises a warning when executed with sudo. 

Don't run Bundler as root. Bundler can ask for sudo if it is needed, and
installing your bundle as root will break this application for all non-root
users on this machine.
