### PR TITLE
Updates only librarian-chef not it's dependencies

### DIFF
--- a/Cheffile
+++ b/Cheffile
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-site 'http://community.opscode.com/api/v1'
+site 'https://supermarket.getchef.com/api/v1'
 
 cookbook 'sprout-rbenv',
   :github => 'pivotal-sprout/sprout-rbenv'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    archive-tar-minitar (0.5.2)
     awesome_print (1.1.0)
     chef (11.6.0)
       erubis
@@ -34,11 +33,12 @@ GEM
     librarian (0.1.2)
       highline
       thor (~> 0.15)
-    librarian-chef (0.0.1)
-      archive-tar-minitar (>= 0.5.2)
+    librarian-chef (0.0.4)
       chef (>= 0.10)
       librarian (~> 0.1.0)
+      minitar (>= 0.5.2)
     mime-types (1.25)
+    minitar (0.5.4)
     mixlib-authentication (1.3.0)
       mixlib-log
     mixlib-cli (1.3.0)


### PR DESCRIPTION
Uses `bundle update --source=librarian-chef` which will only update the source gem and required dependencies, not all depenencies. There is an issue with json versions when all dependencies are updated.  Something to do with json 1.8.1 and 1.7.7

Also updates the Cheffile site.
[#75083494]
