### PR TITLE
Remove stray quote

### DIFF
--- a/soloistrc
+++ b/soloistrc
@@ -66,7 +66,7 @@ node_attributes:
       auto_hide: true
       clear_apps: true
       tile_size: 35
-      magnification': false
+      magnification: false
     homebrew:
       formulae:
         - ctags-exuberant


### PR DESCRIPTION
I was a little surprised that this was considered valid YAML. I have assumed but not confirmed that the intended key is indeed `magnification`.