### PR TITLE
Add pstree back to brew list

### DIFF
--- a/soloistrc
+++ b/soloistrc
@@ -72,7 +72,7 @@ node_attributes:
         - chromedriver
         - imagemagick
         - node
-        # - pstree # Skip until download url is fixed: https://github.com/Homebrew/homebrew/pull/35135
+        - pstree
         - qt
         - ssh-copy-id
         - tmux


### PR DESCRIPTION
The issue referenced in https://github.com/pivotal-sprout/sprout-wrap/commit/e165fe9887bf1d1389551e7a7baf3e71559610a5 has been fixed