### PR TITLE
Remove `softwareupdate` from Travis install step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: objective-c
 rvm: system
+osx_image: xcode7
 install:
   - travis_wait 'sudo softwareupdate -i -a'
   - sudo gem install bundler --no-ri --no-rdoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: objective-c
 rvm: system
 osx_image: xcode7
 install:
-  - travis_wait 'sudo softwareupdate -i -a'
   - sudo gem install bundler --no-ri --no-rdoc
   - sudo ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future bundle install
 script:

--- a/Cheffile.lock
+++ b/Cheffile.lock
@@ -3,7 +3,7 @@ SITE
   specs:
     build-essential (2.2.3)
     dmg (2.2.2)
-    homebrew (1.12.0)
+    homebrew (1.13.0)
       build-essential (>= 2.1.2)
 
 GIT
@@ -32,10 +32,11 @@ GIT
 GIT
   remote: https://github.com/pivotal-sprout/sprout-homebrew
   ref: master
-  sha: 67a6a6ba55d9d8e933645ae7fd1331b85b05d1d0
+  sha: bfcc9b809638bb5cb3d6260aef61ed4de82c2445
   specs:
-    sprout-homebrew (0.1.0)
+    sprout-homebrew (0.2.0)
       homebrew (>= 1.5.4)
+      sprout-base (>= 0.0.0)
 
 GIT
   remote: https://github.com/pivotal-sprout/sprout-jetbrains-editors


### PR DESCRIPTION
Using OS X 10.10.4 means that `softwareupdate` takes a much shorter amount of time, so we no longer need to pre-update.