### PR TITLE
Install iTerm and ShiftIt sooner

### DIFF
--- a/soloistrc
+++ b/soloistrc
@@ -27,12 +27,10 @@ recipes:
 
 # apps
 - sprout-osx-apps::iterm2
-- sprout-osx-apps::flycut
 - sprout-osx-apps::shiftit
 
 # apps (editors)
 - sprout-osx-apps::textmate_preferences
-- sprout-osx-apps::macvim
 - sprout-jetbrains-editors::rubymine
 
 node_attributes:
@@ -84,11 +82,13 @@ node_attributes:
       casks:
         - ccmenu
         - firefox
+        - flycut
         - gitx-rowanj
         - github
         - google-chrome
         - google-drive
         - google-hangouts
+        - macvim
         - skype
         - textmate
         - vagrant

--- a/soloistrc
+++ b/soloistrc
@@ -6,6 +6,10 @@ recipes:
 - sprout-base::homebrew
 - sprout-homebrew
 
+# apps
+- sprout-osx-apps::iterm2
+- sprout-osx-apps::shiftit
+
 # settings
 - sprout-osx-settings
 - sprout-osx-settings::dock_preferences
@@ -24,10 +28,6 @@ recipes:
 - sprout-ruby
 - sprout-mysql
 - sprout-postgresql
-
-# apps
-- sprout-osx-apps::iterm2
-- sprout-osx-apps::shiftit
 
 # apps (editors)
 - sprout-osx-apps::textmate_preferences


### PR DESCRIPTION
They install pretty quickly and improve the usability of a new system. Let's make sure they install soon, so we don't have to wait for Ruby, databases, etc.