### PR TITLE
cask name change fix, and some minor additions

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -31,3 +31,27 @@ There are primarily 2 reasons that we install XCode in sprout-wrap:
     
 1. System Ruby on OS X Mountain Lion uses `xcrun` to detect `cc`. `xcrun` is [not designed](http://stackoverflow.com/questions/13041525/osx-10-8-xcrun-no-such-file-or-directory) to work with the standalone Command Line Tools.
 2. sprout-wrap is used to build workstations for iOS development. Having XCode available is handy in this situation.
+
+#### What are some other common chef recipes worth adding
+
+- sprout-jetbrains-editors::intellij
+- sprout-jetbrains-editors::webstorm
+- sprout-git::git_duet (worth reading the docs, useful for pairing)
+- sprout-git::authors 
+
+homebrew:
+  taps:
+    - caskroom/versions # (if you're not familiar with homebrew -- this tap lets you grab other versions of common casks)
+
+#### Soloist doesn't complete the install process
+
+1. Make sure you have followed the instructions in the readme
+2. Look at the actual command that failed, and re-run it from the command line (e.g. /usr/local/bin/rbenv install 2.1.5)
+
+### My application dock has disappered after running this!
+
+1. It's on the left hand side, change "dock::orientation: 'left' to 'bottom' if you want to adjust this
+
+
+
+

--- a/soloistrc
+++ b/soloistrc
@@ -5,6 +5,7 @@ recipes:
 - sprout-base::bash_it
 - sprout-base::homebrew
 - sprout-homebrew
+- homebrew::install_taps
 
 # apps
 - sprout-osx-apps::iterm2
@@ -79,6 +80,7 @@ node_attributes:
         - wget
         - rbenv-binstubs
         - rbenv-gem-rehash
+        - cloudfoundry-cli   
       casks:
         - ccmenu
         - firefox
@@ -95,3 +97,6 @@ node_attributes:
         - virtualbox
         - xquartz
         - xscope
+
+      taps:
+        - pivotal/tap

--- a/soloistrc
+++ b/soloistrc
@@ -80,8 +80,9 @@ node_attributes:
         - wget
         - rbenv-binstubs
         - rbenv-gem-rehash
-        - cloudfoundry-cli   
+ 
       casks:
+        - cloudfoundry-cli  
         - ccmenu
         - firefox
         - flycut

--- a/soloistrc
+++ b/soloistrc
@@ -83,7 +83,7 @@ node_attributes:
         - ccmenu
         - firefox
         - flycut
-        - gitx-rowanj
+        - rowanj-gitx
         - github
         - google-chrome
         - google-drive


### PR DESCRIPTION
Really enjoying using sprout-wrap.  Noticed that gitx wasn't installing, looks like the cask name may have changed.    While fixing that, felt that the CF CLI should really be part of the base install, and added some more FAQs based on things I'd heard from others who were using it.

