### PR TITLE
Remove rbenv-gem-rehash

### DIFF
--- a/soloistrc
+++ b/soloistrc
@@ -78,7 +78,6 @@ node_attributes:
         - watch
         - wget
         - rbenv-binstubs
-        - rbenv-gem-rehash
       casks:
         - ccmenu
         - firefox


### PR DESCRIPTION
It's no longer available on Homebrew