### PR TITLE
Remove deprecated rbenv-gem-rehash

### DIFF
--- a/soloistrc
+++ b/soloistrc
@@ -78,7 +78,6 @@ node_attributes:
         - watch
         - wget
         - rbenv-binstubs
-        - rbenv-gem-rehash
       casks:
         - ccmenu
         - firefox


### PR DESCRIPTION
The formula for `rbenv-gem-rehash` has been deprecated and removed from brew. This functionality is now baked into rbenv core and the plugin is no longer necessary.

[The repository](https://github.com/rbenv/rbenv-gem-rehash)

[The pull request removing it from brew](https://github.com/Homebrew/homebrew/pull/47375)